### PR TITLE
Add support for named trackers (Google Tag Manager)

### DIFF
--- a/ember-google-analytics.js
+++ b/ember-google-analytics.js
@@ -4,7 +4,7 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
   },
 
   getTrackerPrefix: function () {
-    var tracker = (ga.getAll() || []).pop();
+    var tracker = (ga.getAll && typeof ga.getAll === "function" && ga.getAll() || []).pop();
     return tracker ? tracker.get('name') + '.' : '';
   },
 

--- a/ember-google-analytics.js
+++ b/ember-google-analytics.js
@@ -3,6 +3,11 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
     return window.ga && typeof window.ga === "function";
   },
 
+  getTrackerPrefix: function () {
+    var tracker = (ga.getAll() || []).pop();
+    return tracker ? tracker.get('name') + '.' : '';
+  },
+
   trackPageView: function(page) {
     if (this.pageHasGa()) {
       if (!page) {
@@ -10,13 +15,13 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
         page = loc.hash ? loc.hash.substring(1) : loc.pathname + loc.search;
       }
 
-      ga('send', 'pageview', page);
+      ga(this.getTrackerPrefix() + 'send', 'pageview', page);
     }
   },
 
   trackEvent: function(category, action, label, value) {
     if (this.pageHasGa()) {
-      ga('send', 'event', category, action, label, value);
+      ga(this.getTrackerPrefix() + 'send', 'event', category, action, label, value);
     }
   }
 });

--- a/lib/tracking_mixin.js
+++ b/lib/tracking_mixin.js
@@ -4,7 +4,7 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
   },
 
   getTrackerPrefix: function () {
-    var tracker = (ga.getAll() || []).pop();
+    var tracker = (ga.getAll && typeof ga.getAll === "function" && ga.getAll() || []).pop();
     return tracker ? tracker.get('name') + '.' : '';
   },
 

--- a/lib/tracking_mixin.js
+++ b/lib/tracking_mixin.js
@@ -3,6 +3,11 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
     return window.ga && typeof window.ga === "function";
   },
 
+  getTrackerPrefix: function () {
+    var tracker = (ga.getAll() || []).pop();
+    return tracker ? tracker.get('name') + '.' : '';
+  },
+
   trackPageView: function(page) {
     if (this.pageHasGa()) {
       if (!page) {
@@ -10,13 +15,13 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
         page = loc.hash ? loc.hash.substring(1) : loc.pathname + loc.search;
       }
 
-      ga('send', 'pageview', page);
+      ga(this.getTrackerPrefix() + 'send', 'pageview', page);
     }
   },
 
   trackEvent: function(category, action, label, value) {
     if (this.pageHasGa()) {
-      ga('send', 'event', category, action, label, value);
+      ga(this.getTrackerPrefix() + 'send', 'event', category, action, label, value);
     }
   }
 });


### PR DESCRIPTION
Google Tag Manager doesn't use the default tracker, so "send" calls need to be prefixed with the tracker id.

This change uses the first tracker if multiple trackers are defined, or no prefix otherwise. This should be sufficient for any standard Google Tag Manager install.

https://groups.google.com/forum/#!topic/google-analytics-analyticsjs/mayu2cf1d0k
https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#multipletrackers
