### PR TITLE
Allow ability to log events / page views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp
 compiled
+.bundle

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ App.VideoController = Ember.Controller.extend(
 
 The mixin can be applied to any Ember object.
 
+## Logging
+
+To enable console logging any events or page views sent to Google Analytics:
+
+```
+window.ENV = window.ENV || {};
+window.ENV.LOG_EVENT_TRACKING = true;
+```
+
 ## Development
 
 This plugin is built with rake pipeline, which requires Ruby. To get

--- a/ember-google-analytics.js
+++ b/ember-google-analytics.js
@@ -3,6 +3,14 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
     return window.ga && typeof window.ga === "function";
   },
 
+  logTrackingEnabled: function() {
+    return !!window.ENV && !!window.ENV.LOG_EVENT_TRACKING;
+  },
+
+  logTracking: function() {
+    Ember.Logger.info('Tracking Google Analytics event: ', arguments);
+  },
+
   trackPageView: function(page) {
     if (this.pageHasGa()) {
       if (!page) {
@@ -12,11 +20,19 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
 
       ga('send', 'pageview', page);
     }
+
+    if (this.logTrackingEnabled()) {
+      this.logTracking('pageview', page);
+    }
   },
 
   trackEvent: function(category, action, label, value) {
     if (this.pageHasGa()) {
       ga('send', 'event', category, action, label, value);
+    }
+
+    if (this.logTrackingEnabled()) {
+      this.logTracking('event', category, action, label, value);
     }
   }
 });

--- a/lib/tracking_mixin.js
+++ b/lib/tracking_mixin.js
@@ -3,6 +3,14 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
     return window.ga && typeof window.ga === "function";
   },
 
+  logTrackingEnabled: function() {
+    return !!window.ENV && !!window.ENV.LOG_EVENT_TRACKING;
+  },
+
+  logTracking: function() {
+    Ember.Logger.info('Tracking Google Analytics event: ', arguments);
+  },
+
   trackPageView: function(page) {
     if (this.pageHasGa()) {
       if (!page) {
@@ -12,11 +20,19 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
 
       ga('send', 'pageview', page);
     }
+
+    if (this.logTrackingEnabled()) {
+      this.logTracking('pageview', page);
+    }
   },
 
   trackEvent: function(category, action, label, value) {
     if (this.pageHasGa()) {
       ga('send', 'event', category, action, label, value);
+    }
+
+    if (this.logTrackingEnabled()) {
+      this.logTracking('event', category, action, label, value);
     }
   }
 });

--- a/tests/unit/tracking_mixin_test.js
+++ b/tests/unit/tracking_mixin_test.js
@@ -1,0 +1,98 @@
+var ObjectWithMixin = Ember.Object.extend(Ember.GoogleAnalyticsTrackingMixin);
+
+var instance;
+var counter;
+var emberInfoLogger = Ember.Logger.info;
+
+module("Logging enabled", {
+  setup: function() {
+    counter = 0;
+    window.ENV = { LOG_EVENT_TRACKING: true };
+    window.logs = [];
+
+    instance = ObjectWithMixin.create();
+
+    Ember.Logger.info = function() {
+      counter = counter + 1;
+    };
+  },
+
+  teardown: function() {
+    window.ENV = null;
+    window.logs = null;
+    Ember.Logger.info = emberInfoLogger;
+    Ember.run(instance, "destroy");
+  }
+});
+
+test("logTracking returns true if LOG_EVENT_TRACKING true", function() {
+  expect(1);
+
+  equal(instance.logTrackingEnabled(), true);
+});
+
+test("logs page views sent to Google Analytics", function() {
+  expect(1);
+
+  instance.trackPageView("/homepage");
+
+  equal(counter, 1);
+});
+
+test("logs events sent to Google Analytics", function() {
+  expect(1);
+
+  instance.trackEvent('Video', 'play', 'youtube', 'http://youtube.com/somevideo');
+
+  equal(counter, 1);
+});
+
+module("Logging disabled", {
+  setup: function() {
+    counter = 0;
+    Ember.Logger.info = function() {
+      counter = counter + 1;
+    };
+    window.ENV = { LOG_EVENT_TRACKING: false };
+
+    instance = ObjectWithMixin.create();
+  },
+
+  teardown: function() {
+    window.ENV = null;
+    Ember.Logger.info = emberInfoLogger;
+    Ember.run(instance, 'destroy');
+  }
+});
+
+test("logTracking returns false if LOG_EVENT_TRACKING false", function() {
+  expect(1);
+
+  equal(instance.logTrackingEnabled(), false);
+});
+
+test("logTracking returns false if window.ENV undefined", function() {
+  window.ENV = null;
+
+  expect(1);
+
+  equal(instance.logTrackingEnabled(), false);
+});
+
+test("does not log page views sent to Google Analytics", function() {
+  expect(1);
+
+  instance.trackPageView("/homepage");
+
+  equal(counter, 0);
+});
+
+
+test("does not log events sent to Google Analytics", function() {
+  expect(1);
+
+  instance.trackEvent('Video', 'play', 'youtube', 'http://youtube.com/somevideo');
+
+
+  equal(counter, 0);
+});


### PR DESCRIPTION
Tried to follow the Ember Core LOG_<this thing> convention that they have with transitions, views, etc. to enable debug level logging.  Added an ENV variable that can be set to console log what would have been sent to Google Analytics.  This helps in debugging in a pre-prod environment where you likely would not include the ga.js library to see what events you'd be sending along to GA.
