### PR TITLE
Added bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-google-analytics",
+  "main": "ember-google-analytics.js",
+  "version": "0.1.0",
+  "homepage": "https://github.com/ryanto/ember-google-analytics",
+  "authors": [
+    "Ryan T"
+  ],
+  "description": "Ember.JS Plugin that makes Google Analytics just work.",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "ember",
+    "google",
+    "analytics"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi, I ran into some issues installing your plugin without a valid bower.json, so I thought I'd offer you a placeholder if you're interested.

Bower can install without the bower.json config file if you just specify a git repo/commit to pull from, but then you can't programmatically make sure that your dependencies are all up to date when you run a build.
