### PR TITLE
include rootURL in tracking url

### DIFF
--- a/ember-google-analytics.js
+++ b/ember-google-analytics.js
@@ -42,7 +42,7 @@ Ember.Application.initializer({
   initialize: function(container, application) {
     var router = container.lookup('router:main');
     router.on('didTransition', function() {
-      this.trackPageView(this.get('url'));
+      this.trackPageView(router.rootURL.slice(0, -1) + this.get('url'));
     });
   }
 });


### PR DESCRIPTION
The current trackPageView does not include the routers rootURL.
