### PR TITLE
Use instance initializer to get instace of the router

### DIFF
--- a/ember-google-analytics.js
+++ b/ember-google-analytics.js
@@ -39,8 +39,14 @@ Ember.GoogleAnalyticsTrackingMixin = Ember.Mixin.create({
 Ember.Application.initializer({
   name: "googleAnalytics",
 
-  initialize: function(container, application) {
-    var router = container.lookup('router:main');
+  initialize: function(registry, application) {
+  }
+});
+Ember.Application.instanceInitializer({
+  name: "googleAnalytics",
+
+  initialize: function(instance) {
+    var router = instance.container.lookup('router:main');
     router.on('didTransition', function() {
       this.trackPageView(router.rootURL.slice(0, -1) + this.get('url'));
     });


### PR DESCRIPTION
This removes the following deprecation:

http://emberjs.com/deprecations/v1.x/#toc_access-to-instances-in-initializers
